### PR TITLE
Do not react to pressed keys when target is input or textarea

### DIFF
--- a/src/hotkeyManager.ts
+++ b/src/hotkeyManager.ts
@@ -5,6 +5,10 @@ class HotKeyManager {
 
   constructor () {
     window.addEventListener('keydown', (e) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return
+      }
+
       this.pressedKeys.set(e.key, e.repeat)
       console.log('key', e.key)
       const keyComb = this.getKeyComb(Array.from(this.pressedKeys.keys()))


### PR DESCRIPTION
At the moment all hotkeys trigger when typing into text fields which makes this package unusable 🤷 