### PR TITLE
Removed console.log from keydown listener

### DIFF
--- a/src/hotkeyManager.ts
+++ b/src/hotkeyManager.ts
@@ -6,7 +6,6 @@ class HotKeyManager {
   constructor () {
     window.addEventListener('keydown', (e) => {
       this.pressedKeys.set(e.key, e.repeat)
-      console.log('key', e.key)
       const keyComb = this.getKeyComb(Array.from(this.pressedKeys.keys()))
       this.registeredHotkeys[keyComb]?.forEach((hotKey) => {
         if (!e.repeat || hotKey?.repeat) {


### PR DESCRIPTION
I've seen this discussed in issue #2, this can be very distracting on a site with a lot of text input.

I would argue that keeping the console log even in a non production environment does not add anything since it just directly logs the window events' key which can be found out by other means.